### PR TITLE
Register notify signals for properties

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -223,6 +223,9 @@ macro_rules! Q_OBJECT{
                             )*
                             signals.push((stringify!($signalname), argc, mttypes));
                         )*
+                        $(
+                            signals.push((stringify!($notify_sig), 0, Vec::new()));
+                        )*
                         let mut slots = Vec::new();
                         $(
                             let mut argc = 0;


### PR DESCRIPTION
When creating custom QObjects using `Q_OBJECT!` the notify signals are not registered with QML, making all properties constant. This PR should fix this. 