### PR TITLE
Replace explicit i8 with libc::c_char, to allow it to compile on ARM.

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,9 +3,9 @@ use libc;
 use std::ffi::CString;
 pub fn stoptr(s: &str) -> *const libc::c_char {
     let cstr = CString::new(s).unwrap();
-    cstr.into_raw() as *const i8
+    cstr.into_raw() as *const libc::c_char
 }
 
-pub fn ptrtos(ptr: *const i8) -> CString {
-    unsafe { CString::from_raw(ptr as *mut i8) }
+pub fn ptrtos(ptr: *const libc::c_char) -> CString {
+    unsafe { CString::from_raw(ptr as *mut libc::c_char) }
 }


### PR DESCRIPTION
Despite the docs saying that libc::c_char is equivalent to i8, it would
appear that libc::c_char actually follows the idiosyncracies of the C
`char` type that it represents. That is, on some platforms it is
equivalent to `signed char` (i8) and on others it is `unsigned char`
(u8). By explicitly using libc::c_char in the `stoptr` and `ptrtos`
functions, we avoid mismatched type errors when compiling on ARM.